### PR TITLE
Fix the base path used for the server config endpoint

### DIFF
--- a/src/main/Out/HttpSubscriptionConfigurationClient.cs
+++ b/src/main/Out/HttpSubscriptionConfigurationClient.cs
@@ -22,7 +22,7 @@ namespace ei8.Cortex.Diary.Nucleus.Client.Out
             );
 
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
-        private static readonly string subscriptionsConfigurationPath = "nuclei/d23/subscriptions";
+        private static readonly string subscriptionsConfigurationPath = "nuclei/d23/subscriptions/config";
 
         public HttpSubscriptionConfigurationClient(IRequestProvider requestProvider = null)
         {


### PR DESCRIPTION
* The incorrect base path was causing errors in the Blazor app when reloading the tree (since the server config is reloaded at that point)