### PR TITLE
Remove extra trailing slashes when building request URLs

### DIFF
--- a/src/main/In/HttpSubscriptionClient.cs
+++ b/src/main/In/HttpSubscriptionClient.cs
@@ -33,7 +33,7 @@ namespace ei8.Cortex.Diary.Nucleus.Client.In
         {
             await HttpSubscriptionClient.exponentialRetryPolicy.ExecuteAsync(async () =>
             {
-                await this.requestProvider.PostAsync($"{baseUrl}/{HttpSubscriptionClient.subscriptionsPath}", subscriptionInfo, token: bearerToken);
+                await this.requestProvider.PostAsync($"{baseUrl}{HttpSubscriptionClient.subscriptionsPath}", subscriptionInfo, token: bearerToken);
             });
         }
     }

--- a/src/main/Out/HttpSubscriptionConfigurationClient.cs
+++ b/src/main/Out/HttpSubscriptionConfigurationClient.cs
@@ -31,9 +31,10 @@ namespace ei8.Cortex.Diary.Nucleus.Client.Out
 
         public async Task<SubscriptionConfiguration> GetServerConfigurationAsync(string baseUrl, CancellationToken token = default)
         {
+            var url = $"{baseUrl}{HttpSubscriptionConfigurationClient.subscriptionsConfigurationPath}";
             return await HttpSubscriptionConfigurationClient.exponentialRetryPolicy.ExecuteAsync(async () =>
             {
-                return await this.requestProvider.GetAsync<SubscriptionConfiguration>($"{baseUrl}/{HttpSubscriptionConfigurationClient.subscriptionsConfigurationPath}", "", token);
+                return await this.requestProvider.GetAsync<SubscriptionConfiguration>(url, "", token);
             });
         }
     }


### PR DESCRIPTION
Some environments are picky with malformed URLs. If there is an extra trailing slash in the request URL and it points to a Docker container the request fails.